### PR TITLE
Add script to delete last transactions from the 'transactions' table

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ To run explorer-admin, `.env` file shoudl be created in the project root directo
 - WALLET_CONNECT_PROJECT_ID - WalletConnect project ID for blockscout frontend _(optional)_
 - IS_TESTNET - whether network is testnet _(optional)_
 - BLOCKSCOUT_TAG - version of skalenetwork/blockscout container to use _(optional)_
+
+## Additional Documentation
+
+For detailed instructions on how to use the delete transactions script, please refer to the [Delete Last Transactions Script Documentation](scripts/README.md).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,42 @@
+## Delete Last Transactions Script
+
+This script allows you to delete the oldest transactions from a database, retaining only the most recent transactions based on the number you specify.
+
+### Usage
+
+```bash
+./scripts/delete_last_transactions.sh [-y | --yes] <schain_name> <N>
+```
+
+- `<schain_name>`: The name of the blockchain (schain) for which the transactions will be deleted.
+- `<N>`: The number of newest transactions that you want to keep in the database.
+
+### Options
+
+- `-y`, `--yes`: (Optional) Skip the confirmation prompt and proceed directly with the deletion.
+
+### How It Works
+
+1. **Confirmation Prompt**: By default, after running the script, you'll be prompted to confirm the deletion by typing `"yes"`. If you use the `-y` or `--yes` flag, the script skips this prompt.
+
+2. **Transaction Deletion**: The script will delete `(total_number_of_transactions - N)` transactions from the `transactions` table, where `total_number_of_transactions` is the current total number of transactions in the database.
+
+3. **Error Handling**: The script checks if:
+   - The specified container is running.
+   - The value of `N` is not greater than the total number of transactions.
+
+   If any of these checks fail, the script will exit with an error message.
+
+### Example
+
+To delete the oldest transactions from the `my_schain` blockchain, keeping the last 100 transactions:
+
+```bash
+./scripts/delete_last_transactions.sh my_schain 100
+```
+
+To run the same command without needing to confirm:
+
+```bash
+./scripts/delete_last_transactions.sh --yes my_schain 100
+```

--- a/scripts/delete_last_transactions.sh
+++ b/scripts/delete_last_transactions.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+if [ "$#" -ne 2 ]; then
+    echo "Usage: $0 <container_name> <N>"
+    exit 1
+fi
+
+CONTAINER_NAME=$1
+N=$2
+
+TOTAL_TRANSACTIONS=$(docker exec "$CONTAINER_NAME" psql -U blockscout -d blockscout -t -c "SELECT COUNT(*) FROM transactions;" | xargs)
+
+if [ "$N" -gt "$TOTAL_TRANSACTIONS" ]; then
+    echo "Error: N ($N) is greater than the total number of transactions ($TOTAL_TRANSACTIONS)."
+    exit 1
+fi
+
+echo "You are about to delete the last $N transactions from the 'transactions' table."
+echo "Total number of transactions: $TOTAL_TRANSACTIONS"
+read -p "Are you sure you want to proceed? Type 'yes' to continue: " CONFIRMATION
+
+if [ "$CONFIRMATION" != "yes" ]; then
+    echo "Operation aborted. No transactions were deleted."
+    exit 0
+fi
+
+docker exec "$CONTAINER_NAME" psql -U blockscout -d blockscout -c "
+WITH rows_to_delete AS (
+    SELECT ctid
+    FROM transactions
+    ORDER BY block_timestamp ASC
+    LIMIT $N
+)
+DELETE FROM transactions
+WHERE ctid IN (SELECT ctid FROM rows_to_delete);
+"
+
+if [ $? -eq 0 ]; then
+    echo "Successfully deleted the last $N transactions from the 'transactions' table."
+else
+    echo "Failed to delete transactions. Please check your input parameters and try again."
+    exit 1
+fi


### PR DESCRIPTION
- added script for keeping N newest transactions
Usage:
`./scripts/delete_last_transactions.sh <schain_name> <N>`
N is the number of newest transactions that you want to keep in database
After running script you need to confirm that you really want to do it and type "yes" after that it will delete `(total_number_of_transactions - N)` number of transactions.
Also there is optional flag which allows to run script without second confirmation. Usage:
Usage: `./scripts/delete_last_transactions.sh  [-y | --yes] <schain_name> <N>`