### PR TITLE
Add default catch-all server block to return 404 for unmatched requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.8
+    - name: Set up Python 3.11
       uses: actions/setup-python@v1
       with:
-        python-version: 3.8
+        python-version: 3.11
     - name: Install python dependencies
       run: |
         python -m pip install --upgrade pip

--- a/admin/configs/nginx.py
+++ b/admin/configs/nginx.py
@@ -10,25 +10,25 @@ def generate_schain_nginx_config(schain_name, explorer_endpoint, ssl=False):
     config = generate_base_nginx_config(schain_name, explorer_endpoint)
     if ssl:
         ssl_block = [
-                {
-                    "directive": "listen",
-                    "args": [
-                        '443',
-                        'ssl'
-                    ]
-                },
-                {
-                    "directive": "ssl_certificate",
-                    "args": [
-                        '/data/server.crt'
-                    ]
-                },
-                {
-                    "directive": "ssl_certificate_key",
-                    "args": [
-                        '/data/server.key'
-                    ]
-                }
+            {
+                "directive": "listen",
+                "args": [
+                    '443',
+                    'ssl'
+                ]
+            },
+            {
+                "directive": "ssl_certificate",
+                "args": [
+                    '/data/server.crt'
+                ]
+            },
+            {
+                "directive": "ssl_certificate_key",
+                "args": [
+                    '/data/server.key'
+                ]
+            }
         ]
         config['block'] = ssl_block + config['block']
     return config
@@ -56,7 +56,7 @@ def generate_base_nginx_config(schain_name, explorer_endpoint):
                 "args": [
                     "/socket"
                 ],
-                "block":[
+                "block": [
                     {
                         "directive": "proxy_http_version",
                         "args": [
@@ -88,7 +88,7 @@ def generate_base_nginx_config(schain_name, explorer_endpoint):
                 "args": [
                     "/"
                 ],
-                "block":[
+                "block": [
                     {
                         "directive": "proxy_pass",
                         "args": [
@@ -99,6 +99,70 @@ def generate_base_nginx_config(schain_name, explorer_endpoint):
             }
         ]
     }
+
+
+def generate_default_nginx_config(ssl=False):
+    """
+    Generates a default catch-all server block that returns a 404 error for any unmatched requests.
+    """
+    config = {
+        "directive": "server",
+        "args": [],
+        "block": [
+            {
+                "directive": "listen",
+                "args": [
+                    '80',
+                    'default_server'
+                ]
+            },
+            {
+                "directive": "server_name",
+                "args": [
+                    "_"
+                ]
+            },
+            {
+                "directive": "location",
+                "args": [
+                    "/"
+                ],
+                "block": [
+                    {
+                        "directive": "return",
+                        "args": [
+                            "404"
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+    if ssl:
+        ssl_block = [
+            {
+                "directive": "listen",
+                "args": [
+                    '443',
+                    'ssl',
+                    'default_server'
+                ]
+            },
+            {
+                "directive": "ssl_certificate",
+                "args": [
+                    '/data/server.crt'
+                ]
+            },
+            {
+                "directive": "ssl_certificate_key",
+                "args": [
+                    '/data/server.key'
+                ]
+            }
+        ]
+        config['block'] = ssl_block + config['block']
+    return config
 
 
 def regenerate_nginx_config():
@@ -117,6 +181,14 @@ def regenerate_nginx_config():
         else:
             schain_config = generate_schain_nginx_config(schain_name, proxy_endpoint)
         nginx_cfg.append(schain_config)
+
+    # Append the default catch-all server block to return a 404 for unmatched requests
+    if SSL_ENABLED and os.path.isfile(SSL_CRT_PATH) and os.path.isfile(SSL_KEY_PATH):
+        default_config = generate_default_nginx_config(ssl=True)
+    else:
+        default_config = generate_default_nginx_config(ssl=False)
+    nginx_cfg.append(default_config)
+
     formatted_config = crossplane.build(nginx_cfg)
     with open(EXPLORERS_NGINX_CONFIG_PATH, 'w') as f:
         f.write(formatted_config)


### PR DESCRIPTION
This pull request includes updates to the `admin/configs/nginx.py` file to enhance the Nginx configuration generation process. The most important changes include the addition of a function to generate a default Nginx configuration and the inclusion of this default configuration in the overall Nginx configuration.

Enhancements to Nginx configuration generation:

* [`admin/configs/nginx.py`](diffhunk://#diff-288fe7124193de25994b2ce84958567331902b71492b29c6707bd8b528215a1bR104-R167): Added a new function `generate_default_nginx_config` to create a default catch-all server block that returns a 404 error for any unmatched requests. This function supports both HTTP and HTTPS configurations.
* [`admin/configs/nginx.py`](diffhunk://#diff-288fe7124193de25994b2ce84958567331902b71492b29c6707bd8b528215a1bR184-R191): Modified the `regenerate_nginx_config` function to append the default catch-all server block to the Nginx configuration. This ensures that any unmatched requests will receive a 404 error.