### PR TITLE
Implement update procedure for Blockscout submodule in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -23,4 +23,14 @@ case "$1" in
 esac
 
 WORKDIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
+
+if [ "$OPTION" = "--update" ]; then
+  BLOCKSCOUT_TAG=$(grep -E '^BLOCKSCOUT_BACKEND_DOCKER_TAG=' "$WORKDIR/.env" | cut -d '=' -f2-)
+  if [ -n "$BLOCKSCOUT_TAG" ]; then
+    echo "Checking out deps/blockscout to tag $BLOCKSCOUT_TAG..."
+    git -C "$WORKDIR/deps/blockscout" fetch --tags
+    git -C "$WORKDIR/deps/blockscout" checkout "$BLOCKSCOUT_TAG"
+  fi
+fi
+
 HOST_DIR_PATH=$WORKDIR OPTION=$OPTION docker compose -f $WORKDIR/docker-compose.yaml up -d --build


### PR DESCRIPTION
Bumping BLOCKSCOUT_BACKEND_DOCKER_TAG in .env and running ./run.sh --update pulls the new image but leaves the deps/blockscout submodule on the old git tag, so its docker-compose.yml no longer matches the image and the compose config breaks. --update should also git checkout the matching tag inside deps/blockscout.

Closes #83 